### PR TITLE
Add Brex and Bilt transfer partners

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Live Demo -> [https://uscreditcardguide.github.io/Wings-of-the-Points/index.html
 
 ## Change Log
 
+### 2021-09-30
+* Added Brex Miles transfer partners.
+* Added Bilt Miles transfer partners.
+
 ### 2021-08-03
 * Air Canada (AC) Aeroplan is now a transfer partner of Chase UR.
 

--- a/index.html
+++ b/index.html
@@ -93,6 +93,8 @@
     { sc: 'amex', name: 'AmEx MR'},
     { sc: 'citi', name: 'Citi TYP'},
     { sc: 'c1', name: 'Capital One'},
+    { sc: 'brex', name: 'Brex'},
+    { sc: 'bilt', name: 'Bilt'},
     { sc: 'marriott', name: 'Marriott Bonvoy'},
     { sc: 'none', name: 'N/A'},
   ]
@@ -217,91 +219,91 @@
   var relations = [{
     type: 'nonAliance',
     relations: [
-      [{ s: 'amex', t: 'ei', f: 1 }, { s: 'citi', t: 'ei', f: 0 }, { s: 'chase', t: 'ei', f: 1 }, { s: 'c1', t: 'ei', f: 0 }, { s: 'marriott', t: 'ei', f: 0 }],
-      [{ s: 'amex', t: 'cz', f: 0 }, { s: 'citi', t: 'cz', f: 0 }, { s: 'chase', t: 'cz', f: 0 }, { s: 'c1', t: 'cz', f: 0 }, { s: 'marriott', t: 'cz', f: 1 }],
-      [{ s: 'amex', t: 'ek', f: 1 }, { s: 'citi', t: 'ek', f: 1 }, { s: 'chase', t: 'ek', f: 1 }, { s: 'c1', t: 'ek', f: 1 }, { s: 'marriott', t: 'ek', f: 1 }],
-      [{ s: 'amex', t: 'ly', f: 0 }, { s: 'citi', t: 'ly', f: 0 }, { s: 'chase', t: 'ly', f: 0 }, { s: 'c1', t: 'ly', f: 0 }, { s: 'marriott', t: 'ly', f: 0 }],
-      [{ s: 'amex', t: 'ey', f: 1 }, { s: 'citi', t: 'ey', f: 1 }, { s: 'chase', t: 'ey', f: 0 }, { s: 'c1', t: 'ey', f: 1 }, { s: 'marriott', t: 'ey', f: 1 }],
-      [{ s: 'amex', t: 'f9', f: 0 }, { s: 'citi', t: 'f9', f: 0 }, { s: 'chase', t: 'f9', f: 0 }, { s: 'c1', t: 'f9', f: 0 }, { s: 'marriott', t: 'f9', f: 1 }],
-      [{ s: 'amex', t: 'hu', f: 0 }, { s: 'citi', t: 'hu', f: 0 }, { s: 'chase', t: 'hu', f: 0 }, { s: 'c1', t: 'hu', f: 0 }, { s: 'marriott', t: 'hu', f: 1 }],
-      [{ s: 'amex', t: 'ha', f: 1 }, { s: 'citi', t: 'ha', f: 0 }, { s: 'chase', t: 'ha', f: 0 }, { s: 'c1', t: 'ha', f: 0 }, { s: 'marriott', t: 'ha', f: 1 }],
-      [{ s: 'amex', t: 'la', f: 0 }, { s: 'citi', t: 'la', f: 0 }, { s: 'chase', t: 'la', f: 0 }, { s: 'c1', t: 'la', f: 0 }, { s: 'marriott', t: 'la', f: 1 }],
-      [{ s: 'amex', t: '9w', f: 0 }, { s: 'citi', t: '9w', f: 1 }, { s: 'chase', t: '9w', f: 0 }, { s: 'c1', t: '9w', f: 0 }, { s: 'marriott', t: '9w', f: 1 }],
-      [{ s: 'amex', t: 'b6', f: 1 }, { s: 'citi', t: 'b6', f: 1 }, { s: 'chase', t: 'b6', f: 1 }, { s: 'c1', t: 'b6', f: 1 }, { s: 'marriott', t: 'b6', f: 1 }],
-      [{ s: 'amex', t: 'wn', f: 0 }, { s: 'citi', t: 'wn', f: 0 }, { s: 'chase', t: 'wn', f: 1 }, { s: 'c1', t: 'wn', f: 0 }, { s: 'marriott', t: 'wn', f: 1 }],
-      [{ s: 'amex', t: 'vs', f: 1 }, { s: 'citi', t: 'vs', f: 1 }, { s: 'chase', t: 'vs', f: 1 }, { s: 'c1', t: 'vs', f: 0 }, { s: 'marriott', t: 'vs', f: 1 }],
-      [{ s: 'amex', t: 'va', f: 0 }, { s: 'citi', t: 'va', f: 0 }, { s: 'chase', t: 'va', f: 0 }, { s: 'c1', t: 'va', f: 0 }, { s: 'marriott', t: 'va', f: 1 }],
+      [{ s: 'amex', t: 'ei', f: 1 }, { s: 'citi', t: 'ei', f: 0 }, { s: 'chase', t: 'ei', f: 1 }, { s: 'c1', t: 'ei', f: 0 }, { s: 'brex', t: 'ei', f: 0 }, { s: 'bilt', t: 'ei', f: 0 }, { s: 'marriott', t: 'ei', f: 0 }],
+      [{ s: 'amex', t: 'cz', f: 0 }, { s: 'citi', t: 'cz', f: 0 }, { s: 'chase', t: 'cz', f: 0 }, { s: 'c1', t: 'cz', f: 0 }, { s: 'brex', t: 'cz', f: 0 }, { s: 'bilt', t: 'cz', f: 0 }, { s: 'marriott', t: 'cz', f: 1 }],
+      [{ s: 'amex', t: 'ek', f: 1 }, { s: 'citi', t: 'ek', f: 1 }, { s: 'chase', t: 'ek', f: 1 }, { s: 'c1', t: 'ek', f: 1 }, { s: 'brex', t: 'ek', f: 1 }, { s: 'bilt', t: 'ek', f: 1 }, { s: 'marriott', t: 'ek', f: 1 }],
+      [{ s: 'amex', t: 'ly', f: 0 }, { s: 'citi', t: 'ly', f: 0 }, { s: 'chase', t: 'ly', f: 0 }, { s: 'c1', t: 'ly', f: 0 }, { s: 'brex', t: 'ly', f: 0 }, { s: 'bilt', t: 'ly', f: 0 }, { s: 'marriott', t: 'ly', f: 0 }],
+      [{ s: 'amex', t: 'ey', f: 1 }, { s: 'citi', t: 'ey', f: 1 }, { s: 'chase', t: 'ey', f: 0 }, { s: 'c1', t: 'ey', f: 1 }, { s: 'brex', t: 'ey', f: 0 }, { s: 'bilt', t: 'ey', f: 0 }, { s: 'marriott', t: 'ey', f: 1 }],
+      [{ s: 'amex', t: 'f9', f: 0 }, { s: 'citi', t: 'f9', f: 0 }, { s: 'chase', t: 'f9', f: 0 }, { s: 'c1', t: 'f9', f: 0 }, { s: 'brex', t: 'f9', f: 0 }, { s: 'bilt', t: 'f9', f: 0 }, { s: 'marriott', t: 'f9', f: 1 }],
+      [{ s: 'amex', t: 'hu', f: 0 }, { s: 'citi', t: 'hu', f: 0 }, { s: 'chase', t: 'hu', f: 0 }, { s: 'c1', t: 'hu', f: 0 }, { s: 'brex', t: 'hu', f: 0 }, { s: 'bilt', t: 'hu', f: 0 }, { s: 'marriott', t: 'hu', f: 1 }],
+      [{ s: 'amex', t: 'ha', f: 1 }, { s: 'citi', t: 'ha', f: 0 }, { s: 'chase', t: 'ha', f: 0 }, { s: 'c1', t: 'ha', f: 0 }, { s: 'brex', t: 'ha', f: 0 }, { s: 'bilt', t: 'ha', f: 1 }, { s: 'marriott', t: 'ha', f: 1 }],
+      [{ s: 'amex', t: 'la', f: 0 }, { s: 'citi', t: 'la', f: 0 }, { s: 'chase', t: 'la', f: 0 }, { s: 'c1', t: 'la', f: 0 }, { s: 'brex', t: 'la', f: 0 }, { s: 'bilt', t: 'la', f: 0 }, { s: 'marriott', t: 'la', f: 1 }],
+      [{ s: 'amex', t: '9w', f: 0 }, { s: 'citi', t: '9w', f: 1 }, { s: 'chase', t: '9w', f: 0 }, { s: 'c1', t: '9w', f: 0 }, { s: 'brex', t: '9w', f: 0 }, { s: 'bilt', t: '9w', f: 0 }, { s: 'marriott', t: '9w', f: 1 }],
+      [{ s: 'amex', t: 'b6', f: 1 }, { s: 'citi', t: 'b6', f: 1 }, { s: 'chase', t: 'b6', f: 1 }, { s: 'c1', t: 'b6', f: 1 }, { s: 'brex', t: 'b6', f: 1 }, { s: 'bilt', t: 'b6', f: 0 }, { s: 'marriott', t: 'b6', f: 1 }],
+      [{ s: 'amex', t: 'wn', f: 0 }, { s: 'citi', t: 'wn', f: 0 }, { s: 'chase', t: 'wn', f: 1 }, { s: 'c1', t: 'wn', f: 0 }, { s: 'brex', t: 'wn', f: 0 }, { s: 'bilt', t: 'wn', f: 0 }, { s: 'marriott', t: 'wn', f: 1 }],
+      [{ s: 'amex', t: 'vs', f: 1 }, { s: 'citi', t: 'vs', f: 1 }, { s: 'chase', t: 'vs', f: 1 }, { s: 'c1', t: 'vs', f: 0 }, { s: 'brex', t: 'vs', f: 0 }, { s: 'bilt', t: 'vs', f: 1 }, { s: 'marriott', t: 'vs', f: 1 }],
+      [{ s: 'amex', t: 'va', f: 0 }, { s: 'citi', t: 'va', f: 0 }, { s: 'chase', t: 'va', f: 0 }, { s: 'c1', t: 'va', f: 0 }, { s: 'brex', t: 'va', f: 0 }, { s: 'bilt', t: 'va', f: 0 }, { s: 'marriott', t: 'va', f: 1 }],
     ]
   }, {
     type: 'oneworld',
     relations: [
-      [{ s: 'amex', t: 'as', f: 0 }, { s: 'citi', t: 'as', f: 0 }, { s: 'chase', t: 'as', f: 0 }, { s: 'c1', t: 'as', f: 0 }, { s: 'marriott', t: 'as', f: 1 }],
-      [{ s: 'amex', t: 'aa', f: 0 }, { s: 'citi', t: 'aa', f: 0 }, { s: 'chase', t: 'aa', f: 0 }, { s: 'c1', t: 'aa', f: 0 }, { s: 'marriott', t: 'aa', f: 1 }],
-      [{ s: 'amex', t: 'ba', f: 1 }, { s: 'citi', t: 'ba', f: 0 }, { s: 'chase', t: 'ba', f: 1 }, { s: 'c1', t: 'ba', f: 1 }, { s: 'marriott', t: 'ba', f: 1 }],
-      [{ s: 'amex', t: 'ib', f: 1 }, { s: 'citi', t: 'ib', f: 0 }, { s: 'chase', t: 'ib', f: 1 }, { s: 'c1', t: 'ib', f: 0 }, { s: 'marriott', t: 'ib', f: 1 }],
-      [{ s: 'amex', t: 'cx', f: 1 }, { s: 'citi', t: 'cx', f: 1 }, { s: 'chase', t: 'cx', f: 0 }, { s: 'c1', t: 'cx', f: 1 }, { s: 'marriott', t: 'cx', f: 1 }],
-      [{ s: 'amex', t: 'ay', f: 0 }, { s: 'citi', t: 'ay', f: 0 }, { s: 'chase', t: 'ay', f: 0 }, { s: 'c1', t: 'ay', f: 1 }, { s: 'marriott', t: 'ay', f: 0 }],
-      [{ s: 'amex', t: 'jl', f: 0 }, { s: 'citi', t: 'jl', f: 0 }, { s: 'chase', t: 'jl', f: 0 }, { s: 'c1', t: 'jl', f: 0 }, { s: 'marriott', t: 'jl', f: 1 }],
-      [{ s: 'amex', t: 'mh', f: 0 }, { s: 'citi', t: 'mh', f: 1 }, { s: 'chase', t: 'mh', f: 0 }, { s: 'c1', t: 'mh', f: 0 }, { s: 'marriott', t: 'mh', f: 0 }],
-      [{ s: 'amex', t: 'qf', f: 1 }, { s: 'citi', t: 'qf', f: 1 }, { s: 'chase', t: 'qf', f: 0 }, { s: 'c1', t: 'qf', f: 1 }, { s: 'marriott', t: 'qf', f: 1 }],
-      [{ s: 'amex', t: 'qr', f: 0 }, { s: 'citi', t: 'qr', f: 1 }, { s: 'chase', t: 'qr', f: 0 }, { s: 'c1', t: 'qr', f: 0 }, { s: 'marriott', t: 'qr', f: 1 }],
-      [{ s: 'amex', t: 'rj', f: 0 }, { s: 'citi', t: 'rj', f: 0 }, { s: 'chase', t: 'rj', f: 0 }, { s: 'c1', t: 'rj', f: 0 }, { s: 'marriott', t: 'rj', f: 0 }],
-      [{ s: 'amex', t: 's7', f: 0 }, { s: 'citi', t: 's7', f: 0 }, { s: 'chase', t: 's7', f: 0 }, { s: 'c1', t: 's7', f: 0 }, { s: 'marriott', t: 's7', f: 0 }],
-      [{ s: 'amex', t: 'ul', f: 0 }, { s: 'citi', t: 'ul', f: 0 }, { s: 'chase', t: 'ul', f: 0 }, { s: 'c1', t: 'ul', f: 0 }, { s: 'marriott', t: 'ul', f: 0 }],
+      [{ s: 'amex', t: 'as', f: 0 }, { s: 'citi', t: 'as', f: 0 }, { s: 'chase', t: 'as', f: 0 }, { s: 'c1', t: 'as', f: 0 }, { s: 'brex', t: 'as', f: 0 }, { s: 'bilt', t: 'as', f: 0 }, { s: 'marriott', t: 'as', f: 1 }],
+      [{ s: 'amex', t: 'aa', f: 0 }, { s: 'citi', t: 'aa', f: 0 }, { s: 'chase', t: 'aa', f: 0 }, { s: 'c1', t: 'aa', f: 0 }, { s: 'brex', t: 'aa', f: 0 }, { s: 'bilt', t: 'aa', f: 1 }, { s: 'marriott', t: 'aa', f: 1 }],
+      [{ s: 'amex', t: 'ba', f: 1 }, { s: 'citi', t: 'ba', f: 0 }, { s: 'chase', t: 'ba', f: 1 }, { s: 'c1', t: 'ba', f: 1 }, { s: 'brex', t: 'ba', f: 0 }, { s: 'bilt', t: 'ba', f: 0 }, { s: 'marriott', t: 'ba', f: 1 }],
+      [{ s: 'amex', t: 'ib', f: 1 }, { s: 'citi', t: 'ib', f: 0 }, { s: 'chase', t: 'ib', f: 1 }, { s: 'c1', t: 'ib', f: 0 }, { s: 'brex', t: 'ib', f: 0 }, { s: 'bilt', t: 'ib', f: 0 }, { s: 'marriott', t: 'ib', f: 1 }],
+      [{ s: 'amex', t: 'cx', f: 1 }, { s: 'citi', t: 'cx', f: 1 }, { s: 'chase', t: 'cx', f: 0 }, { s: 'c1', t: 'cx', f: 1 }, { s: 'brex', t: 'cx', f: 1 }, { s: 'bilt', t: 'cx', f: 0 }, { s: 'marriott', t: 'cx', f: 1 }],
+      [{ s: 'amex', t: 'ay', f: 0 }, { s: 'citi', t: 'ay', f: 0 }, { s: 'chase', t: 'ay', f: 0 }, { s: 'c1', t: 'ay', f: 1 }, { s: 'brex', t: 'ay', f: 0 }, { s: 'bilt', t: 'ay', f: 0 }, { s: 'marriott', t: 'ay', f: 0 }],
+      [{ s: 'amex', t: 'jl', f: 0 }, { s: 'citi', t: 'jl', f: 0 }, { s: 'chase', t: 'jl', f: 0 }, { s: 'c1', t: 'jl', f: 0 }, { s: 'brex', t: 'jl', f: 0 }, { s: 'bilt', t: 'jl', f: 0 }, { s: 'marriott', t: 'jl', f: 1 }],
+      [{ s: 'amex', t: 'mh', f: 0 }, { s: 'citi', t: 'mh', f: 1 }, { s: 'chase', t: 'mh', f: 0 }, { s: 'c1', t: 'mh', f: 0 }, { s: 'brex', t: 'mh', f: 0 }, { s: 'bilt', t: 'mh', f: 0 }, { s: 'marriott', t: 'mh', f: 0 }],
+      [{ s: 'amex', t: 'qf', f: 1 }, { s: 'citi', t: 'qf', f: 1 }, { s: 'chase', t: 'qf', f: 0 }, { s: 'c1', t: 'qf', f: 1 }, { s: 'brex', t: 'qf', f: 1 }, { s: 'bilt', t: 'qf', f: 0 }, { s: 'marriott', t: 'qf', f: 1 }],
+      [{ s: 'amex', t: 'qr', f: 0 }, { s: 'citi', t: 'qr', f: 1 }, { s: 'chase', t: 'qr', f: 0 }, { s: 'c1', t: 'qr', f: 0 }, { s: 'brex', t: 'qr', f: 0 }, { s: 'bilt', t: 'qr', f: 0 }, { s: 'marriott', t: 'qr', f: 1 }],
+      [{ s: 'amex', t: 'rj', f: 0 }, { s: 'citi', t: 'rj', f: 0 }, { s: 'chase', t: 'rj', f: 0 }, { s: 'c1', t: 'rj', f: 0 }, { s: 'brex', t: 'rj', f: 0 }, { s: 'bilt', t: 'rj', f: 0 }, { s: 'marriott', t: 'rj', f: 0 }],
+      [{ s: 'amex', t: 's7', f: 0 }, { s: 'citi', t: 's7', f: 0 }, { s: 'chase', t: 's7', f: 0 }, { s: 'c1', t: 's7', f: 0 }, { s: 'brex', t: 's7', f: 0 }, { s: 'bilt', t: 's7', f: 0 }, { s: 'marriott', t: 's7', f: 0 }],
+      [{ s: 'amex', t: 'ul', f: 0 }, { s: 'citi', t: 'ul', f: 0 }, { s: 'chase', t: 'ul', f: 0 }, { s: 'c1', t: 'ul', f: 0 }, { s: 'brex', t: 'ul', f: 0 }, { s: 'bilt', t: 'ul', f: 0 }, { s: 'marriott', t: 'ul', f: 0 }],
     ]
   }, {
     type: 'skyteam',
     relations: [
-      [{ s: 'amex', t: 'su', f: 0 }, { s: 'citi', t: 'su', f: 0 }, { s: 'chase', t: 'su', f: 0 }, { s: 'c1', t: 'su', f: 0 }, { s: 'marriott', t: 'su', f: 1 }],
-      [{ s: 'amex', t: 'ar', f: 0 }, { s: 'citi', t: 'ar', f: 0 }, { s: 'chase', t: 'ar', f: 0 }, { s: 'c1', t: 'ar', f: 0 }, { s: 'marriott', t: 'ar', f: 0 }],
-      [{ s: 'amex', t: 'am', f: 1 }, { s: 'citi', t: 'am', f: 1 }, { s: 'chase', t: 'am', f: 0 }, { s: 'c1', t: 'am', f: 1 }, { s: 'marriott', t: 'am', f: 1 }],
-      [{ s: 'amex', t: 'ux', f: 0 }, { s: 'citi', t: 'ux', f: 0 }, { s: 'chase', t: 'ux', f: 0 }, { s: 'c1', t: 'ux', f: 0 }, { s: 'marriott', t: 'ux', f: 0 }],
-      [{ s: 'amex', t: 'af', f: 1 }, { s: 'citi', t: 'af', f: 1 }, { s: 'chase', t: 'af', f: 1 }, { s: 'c1', t: 'af', f: 1 }, { s: 'marriott', t: 'af', f: 1 }],
-      [{ s: 'amex', t: 'az', f: 1 }, { s: 'citi', t: 'az', f: 0 }, { s: 'chase', t: 'az', f: 0 }, { s: 'c1', t: 'az', f: 1 }, { s: 'marriott', t: 'az', f: 1 }],
-      [{ s: 'amex', t: 'ci', f: 0 }, { s: 'citi', t: 'ci', f: 0 }, { s: 'chase', t: 'ci', f: 0 }, { s: 'c1', t: 'ci', f: 0 }, { s: 'marriott', t: 'ci', f: 0 }],
-      [{ s: 'amex', t: 'mu', f: 0 }, { s: 'citi', t: 'mu', f: 0 }, { s: 'chase', t: 'mu', f: 0 }, { s: 'c1', t: 'mu', f: 0 }, { s: 'marriott', t: 'mu', f: 0 }],
-      [{ s: 'amex', t: 'ok', f: 0 }, { s: 'citi', t: 'ok', f: 0 }, { s: 'chase', t: 'ok', f: 0 }, { s: 'c1', t: 'ok', f: 0 }, { s: 'marriott', t: 'ok', f: 0 }],
-      [{ s: 'amex', t: 'dl', f: 1 }, { s: 'citi', t: 'dl', f: 0 }, { s: 'chase', t: 'dl', f: 0 }, { s: 'c1', t: 'dl', f: 0 }, { s: 'marriott', t: 'dl', f: 1 }],
-      [{ s: 'amex', t: 'ga', f: 0 }, { s: 'citi', t: 'ga', f: 0 }, { s: 'chase', t: 'ga', f: 0 }, { s: 'c1', t: 'ga', f: 0 }, { s: 'marriott', t: 'ga', f: 0 }],
-      //[{ s: 'amex', t: 'kq', f: 1 }, { s: 'citi', t: 'kq', f: 1 }, { s: 'chase', t: 'kq', f: 1 }, { s: 'c1', t: 'kq', f: 1 }, { s: 'marriott', t: 'kq', f: 1 }],
-      //[{ s: 'amex', t: 'kl', f: 1 }, { s: 'citi', t: 'kl', f: 1 }, { s: 'chase', t: 'kl', f: 1 }, { s: 'c1', t: 'kl', f: 1 }, { s: 'marriott', t: 'kl', f: 1 }],
-      [{ s: 'amex', t: 'ke', f: 0 }, { s: 'citi', t: 'ke', f: 0 }, { s: 'chase', t: 'ke', f: 0 }, { s: 'c1', t: 'ke', f: 0 }, { s: 'marriott', t: 'ke', f: 1 }],
-      [{ s: 'amex', t: 'me', f: 0 }, { s: 'citi', t: 'me', f: 0 }, { s: 'chase', t: 'me', f: 0 }, { s: 'c1', t: 'me', f: 0 }, { s: 'marriott', t: 'me', f: 0 }],
-      [{ s: 'amex', t: 'sv', f: 0 }, { s: 'citi', t: 'sv', f: 0 }, { s: 'chase', t: 'sv', f: 0 }, { s: 'c1', t: 'sv', f: 0 }, { s: 'marriott', t: 'sv', f: 1 }],
-      //[{ s: 'amex', t: 'ro', f: 1 }, { s: 'citi', t: 'ro', f: 1 }, { s: 'chase', t: 'ro', f: 1 }, { s: 'c1', t: 'ro', f: 1 }, { s: 'marriott', t: 'ro', f: 1 }],
-      [{ s: 'amex', t: 'vn', f: 0 }, { s: 'citi', t: 'vn', f: 0 }, { s: 'chase', t: 'vn', f: 0 }, { s: 'c1', t: 'vn', f: 0 }, { s: 'marriott', t: 'vn', f: 0 }],
-      [{ s: 'amex', t: 'mf', f: 0 }, { s: 'citi', t: 'mf', f: 0 }, { s: 'chase', t: 'mf', f: 0 }, { s: 'c1', t: 'mf', f: 0 }, { s: 'marriott', t: 'mf', f: 0 }],
+      [{ s: 'amex', t: 'su', f: 0 }, { s: 'citi', t: 'su', f: 0 }, { s: 'chase', t: 'su', f: 0 }, { s: 'c1', t: 'su', f: 0 }, { s: 'brex', t: 'su', f: 0 }, { s: 'bilt', t: 'su', f: 0 }, { s: 'marriott', t: 'su', f: 1 }],
+      [{ s: 'amex', t: 'ar', f: 0 }, { s: 'citi', t: 'ar', f: 0 }, { s: 'chase', t: 'ar', f: 0 }, { s: 'c1', t: 'ar', f: 0 }, { s: 'brex', t: 'ar', f: 0 }, { s: 'bilt', t: 'ar', f: 0 }, { s: 'marriott', t: 'ar', f: 0 }],
+      [{ s: 'amex', t: 'am', f: 1 }, { s: 'citi', t: 'am', f: 1 }, { s: 'chase', t: 'am', f: 0 }, { s: 'c1', t: 'am', f: 1 }, { s: 'brex', t: 'am', f: 1 }, { s: 'bilt', t: 'am', f: 0 }, { s: 'marriott', t: 'am', f: 1 }],
+      [{ s: 'amex', t: 'ux', f: 0 }, { s: 'citi', t: 'ux', f: 0 }, { s: 'chase', t: 'ux', f: 0 }, { s: 'c1', t: 'ux', f: 0 }, { s: 'brex', t: 'ux', f: 0 }, { s: 'bilt', t: 'ux', f: 0 }, { s: 'marriott', t: 'ux', f: 0 }],
+      [{ s: 'amex', t: 'af', f: 1 }, { s: 'citi', t: 'af', f: 1 }, { s: 'chase', t: 'af', f: 1 }, { s: 'c1', t: 'af', f: 1 }, { s: 'brex', t: 'af', f: 1 }, { s: 'bilt', t: 'af', f: 1 }, { s: 'marriott', t: 'af', f: 1 }],
+      [{ s: 'amex', t: 'az', f: 1 }, { s: 'citi', t: 'az', f: 0 }, { s: 'chase', t: 'az', f: 0 }, { s: 'c1', t: 'az', f: 1 }, { s: 'brex', t: 'az', f: 0 }, { s: 'bilt', t: 'az', f: 0 }, { s: 'marriott', t: 'az', f: 1 }],
+      [{ s: 'amex', t: 'ci', f: 0 }, { s: 'citi', t: 'ci', f: 0 }, { s: 'chase', t: 'ci', f: 0 }, { s: 'c1', t: 'ci', f: 0 }, { s: 'brex', t: 'ci', f: 0 }, { s: 'bilt', t: 'ci', f: 0 }, { s: 'marriott', t: 'ci', f: 0 }],
+      [{ s: 'amex', t: 'mu', f: 0 }, { s: 'citi', t: 'mu', f: 0 }, { s: 'chase', t: 'mu', f: 0 }, { s: 'c1', t: 'mu', f: 0 }, { s: 'brex', t: 'mu', f: 0 }, { s: 'bilt', t: 'mu', f: 0 }, { s: 'marriott', t: 'mu', f: 0 }],
+      [{ s: 'amex', t: 'ok', f: 0 }, { s: 'citi', t: 'ok', f: 0 }, { s: 'chase', t: 'ok', f: 0 }, { s: 'c1', t: 'ok', f: 0 }, { s: 'brex', t: 'ok', f: 0 }, { s: 'bilt', t: 'ok', f: 0 }, { s: 'marriott', t: 'ok', f: 0 }],
+      [{ s: 'amex', t: 'dl', f: 1 }, { s: 'citi', t: 'dl', f: 0 }, { s: 'chase', t: 'dl', f: 0 }, { s: 'c1', t: 'dl', f: 0 }, { s: 'brex', t: 'dl', f: 0 }, { s: 'bilt', t: 'dl', f: 0 }, { s: 'marriott', t: 'dl', f: 1 }],
+      [{ s: 'amex', t: 'ga', f: 0 }, { s: 'citi', t: 'ga', f: 0 }, { s: 'chase', t: 'ga', f: 0 }, { s: 'c1', t: 'ga', f: 0 }, { s: 'brex', t: 'ga', f: 0 }, { s: 'bilt', t: 'ga', f: 0 }, { s: 'marriott', t: 'ga', f: 0 }],
+      //[{ s: 'amex', t: 'kq', f: 1 }, { s: 'citi', t: 'kq', f: 1 }, { s: 'chase', t: 'kq', f: 1 }, { s: 'c1', t: 'kq', f: 1 }, { s: 'brex', t: 'kq', f: 0 }, { s: 'bilt', t: 'kq', f: 0 }, { s: 'marriott', t: 'kq', f: 1 }],
+      //[{ s: 'amex', t: 'kl', f: 1 }, { s: 'citi', t: 'kl', f: 1 }, { s: 'chase', t: 'kl', f: 1 }, { s: 'c1', t: 'kl', f: 1 }, { s: 'brex', t: 'kl', f: 0 }, { s: 'bilt', t: 'kl', f: 0 }, { s: 'marriott', t: 'kl', f: 1 }],
+      [{ s: 'amex', t: 'ke', f: 0 }, { s: 'citi', t: 'ke', f: 0 }, { s: 'chase', t: 'ke', f: 0 }, { s: 'c1', t: 'ke', f: 0 }, { s: 'brex', t: 'ke', f: 0 }, { s: 'bilt', t: 'ke', f: 0 }, { s: 'marriott', t: 'ke', f: 1 }],
+      [{ s: 'amex', t: 'me', f: 0 }, { s: 'citi', t: 'me', f: 0 }, { s: 'chase', t: 'me', f: 0 }, { s: 'c1', t: 'me', f: 0 }, { s: 'brex', t: 'me', f: 0 }, { s: 'bilt', t: 'me', f: 0 }, { s: 'marriott', t: 'me', f: 0 }],
+      [{ s: 'amex', t: 'sv', f: 0 }, { s: 'citi', t: 'sv', f: 0 }, { s: 'chase', t: 'sv', f: 0 }, { s: 'c1', t: 'sv', f: 0 }, { s: 'brex', t: 'sv', f: 0 }, { s: 'bilt', t: 'sv', f: 0 }, { s: 'marriott', t: 'sv', f: 1 }],
+      //[{ s: 'amex', t: 'ro', f: 1 }, { s: 'citi', t: 'ro', f: 1 }, { s: 'chase', t: 'ro', f: 1 }, { s: 'c1', t: 'ro', f: 1 }, { s: 'brex', t: 'ro', f: 0 }, { s: 'bilt', t: 'ro', f: 0 }, { s: 'marriott', t: 'ro', f: 1 }],
+      [{ s: 'amex', t: 'vn', f: 0 }, { s: 'citi', t: 'vn', f: 0 }, { s: 'chase', t: 'vn', f: 0 }, { s: 'c1', t: 'vn', f: 0 }, { s: 'brex', t: 'vn', f: 0 }, { s: 'bilt', t: 'vn', f: 0 }, { s: 'marriott', t: 'vn', f: 0 }],
+      [{ s: 'amex', t: 'mf', f: 0 }, { s: 'citi', t: 'mf', f: 0 }, { s: 'chase', t: 'mf', f: 0 }, { s: 'c1', t: 'mf', f: 0 }, { s: 'brex', t: 'mf', f: 0 }, { s: 'bilt', t: 'mf', f: 0 }, { s: 'marriott', t: 'mf', f: 0 }],
     ]
   }, {
     type: 'starAlliance',
     relations: [
-      //[{ s: 'amex', t: 'jp', f: 0 }, { s: 'citi', t: 'jp', f: 0 }, { s: 'chase', t: 'jp', f: 0 }, { s: 'c1', t: 'jp', f: 0 }, { s: 'marriott', t: 'jp', f: 0 }],
-      [{ s: 'amex', t: 'a3', f: 0 }, { s: 'citi', t: 'a3', f: 0 }, { s: 'chase', t: 'a3', f: 0 }, { s: 'c1', t: 'a3', f: 0 }, { s: 'marriott', t: 'a3', f: 1 }],
-      [{ s: 'amex', t: 'ac', f: 1 }, { s: 'citi', t: 'ac', f: 0 }, { s: 'chase', t: 'ac', f: 1 }, { s: 'c1', t: 'ac', f: 1 }, { s: 'marriott', t: 'ac', f: 1 }],
-      [{ s: 'amex', t: 'ca', f: 0 }, { s: 'citi', t: 'ca', f: 0 }, { s: 'chase', t: 'ca', f: 0 }, { s: 'c1', t: 'ca', f: 0 }, { s: 'marriott', t: 'ca', f: 1 }],
-      [{ s: 'amex', t: 'ai', f: 0 }, { s: 'citi', t: 'ai', f: 0 }, { s: 'chase', t: 'ai', f: 0 }, { s: 'c1', t: 'ai', f: 0 }, { s: 'marriott', t: 'ai', f: 0 }],
-      [{ s: 'amex', t: 'nz', f: 0 }, { s: 'citi', t: 'nz', f: 0 }, { s: 'chase', t: 'nz', f: 0 }, { s: 'c1', t: 'nz', f: 0 }, { s: 'marriott', t: 'nz', f: 1 }],
-      [{ s: 'amex', t: 'nh', f: 1 }, { s: 'citi', t: 'nh', f: 0 }, { s: 'chase', t: 'nh', f: 0 }, { s: 'c1', t: 'nh', f: 0 }, { s: 'marriott', t: 'nh', f: 1 }],
-      [{ s: 'amex', t: 'oz', f: 0 }, { s: 'citi', t: 'oz', f: 0 }, { s: 'chase', t: 'oz', f: 0 }, { s: 'c1', t: 'oz', f: 0 }, { s: 'marriott', t: 'oz', f: 1 }],
-      //[{ s: 'amex', t: 'os', f: 0 }, { s: 'citi', t: 'os', f: 0 }, { s: 'chase', t: 'os', f: 0 }, { s: 'c1', t: 'os', f: 0 }, { s: 'marriott', t: 'os', f: 0 }],
-      [{ s: 'amex', t: 'av', f: 1 }, { s: 'citi', t: 'av', f: 1 }, { s: 'chase', t: 'av', f: 0 }, { s: 'c1', t: 'av', f: 1 }, { s: 'marriott', t: 'av', f: 1 }],
-      //[{ s: 'amex', t: 'sn', f: 0 }, { s: 'citi', t: 'sn', f: 0 }, { s: 'chase', t: 'sn', f: 0 }, { s: 'c1', t: 'sn', f: 0 }, { s: 'marriott', t: 'sn', f: 0 }],
-      [{ s: 'amex', t: 'cm', f: 0 }, { s: 'citi', t: 'cm', f: 0 }, { s: 'chase', t: 'cm', f: 0 }, { s: 'c1', t: 'cm', f: 0 }, { s: 'marriott', t: 'cm', f: 1 }],
-      //[{ s: 'amex', t: 'ou', f: 0 }, { s: 'citi', t: 'ou', f: 0 }, { s: 'chase', t: 'ou', f: 0 }, { s: 'c1', t: 'ou', f: 0 }, { s: 'marriott', t: 'ou', f: 0 }],
-      [{ s: 'amex', t: 'ms', f: 0 }, { s: 'citi', t: 'ms', f: 0 }, { s: 'chase', t: 'ms', f: 0 }, { s: 'c1', t: 'ms', f: 0 }, { s: 'marriott', t: 'ms', f: 0 }],
-      [{ s: 'amex', t: 'et', f: 0 }, { s: 'citi', t: 'et', f: 0 }, { s: 'chase', t: 'et', f: 0 }, { s: 'c1', t: 'et', f: 0 }, { s: 'marriott', t: 'et', f: 0 }],
-      [{ s: 'amex', t: 'br', f: 0 }, { s: 'citi', t: 'br', f: 1 }, { s: 'chase', t: 'br', f: 0 }, { s: 'c1', t: 'br', f: 1 }, { s: 'marriott', t: 'br', f: 0 }],
-      //[{ s: 'amex', t: 'lo', f: 0 }, { s: 'citi', t: 'lo', f: 0 }, { s: 'chase', t: 'lo', f: 0 }, { s: 'c1', t: 'lo', f: 0 }, { s: 'marriott', t: 'lo', f: 0 }],
-      [{ s: 'amex', t: 'lh', f: 0 }, { s: 'citi', t: 'lh', f: 0 }, { s: 'chase', t: 'lh', f: 0 }, { s: 'c1', t: 'lh', f: 0 }, { s: 'marriott', t: 'lh', f: 0 }],
-      [{ s: 'amex', t: 'sk', f: 0 }, { s: 'citi', t: 'sk', f: 0 }, { s: 'chase', t: 'sk', f: 0 }, { s: 'c1', t: 'sk', f: 0 }, { s: 'marriott', t: 'sk', f: 0 }],
-      [{ s: 'amex', t: 'zh', f: 0 }, { s: 'citi', t: 'zh', f: 0 }, { s: 'chase', t: 'zh', f: 0 }, { s: 'c1', t: 'zh', f: 0 }, { s: 'marriott', t: 'zh', f: 1 }],
-      [{ s: 'amex', t: 'sq', f: 1 }, { s: 'citi', t: 'sq', f: 1 }, { s: 'chase', t: 'sq', f: 1 }, { s: 'c1', t: 'sq', f: 1 }, { s: 'marriott', t: 'sq', f: 1 }],
-      [{ s: 'amex', t: 'sa', f: 0 }, { s: 'citi', t: 'sa', f: 0 }, { s: 'chase', t: 'sa', f: 0 }, { s: 'c1', t: 'sa', f: 0 }, { s: 'marriott', t: 'sa', f: 1 }],
-      //[{ s: 'amex', t: 'lx', f: 0 }, { s: 'citi', t: 'lx', f: 0 }, { s: 'chase', t: 'lx', f: 0 }, { s: 'c1', t: 'lx', f: 0 }, { s: 'marriott', t: 'lx', f: 0 }],
-      [{ s: 'amex', t: 'tp', f: 0 }, { s: 'citi', t: 'tp', f: 0 }, { s: 'chase', t: 'tp', f: 0 }, { s: 'c1', t: 'tp', f: 1 }, { s: 'marriott', t: 'tp', f: 1 }],
-      [{ s: 'amex', t: 'tg', f: 0 }, { s: 'citi', t: 'tg', f: 1 }, { s: 'chase', t: 'tg', f: 0 }, { s: 'c1', t: 'tg', f: 0 }, { s: 'marriott', t: 'tg', f: 1 }],
-      [{ s: 'amex', t: 'tk', f: 0 }, { s: 'citi', t: 'tk', f: 1 }, { s: 'chase', t: 'tk', f: 0 }, { s: 'c1', t: 'tk', f: 1 }, { s: 'marriott', t: 'tk', f: 1 }],
-      [{ s: 'amex', t: 'ua', f: 0 }, { s: 'citi', t: 'ua', f: 0 }, { s: 'chase', t: 'ua', f: 1 }, { s: 'c1', t: 'ua', f: 0 }, { s: 'marriott', t: 'ua', f: 1 }],
+      //[{ s: 'amex', t: 'jp', f: 0 }, { s: 'citi', t: 'jp', f: 0 }, { s: 'chase', t: 'jp', f: 0 }, { s: 'c1', t: 'jp', f: 0 }, { s: 'brex', t: 'jp', f: 0 }, { s: 'bilt', t: 'jp', f: 0 }, { s: 'marriott', t: 'jp', f: 0 }],
+      [{ s: 'amex', t: 'a3', f: 0 }, { s: 'citi', t: 'a3', f: 0 }, { s: 'chase', t: 'a3', f: 0 }, { s: 'c1', t: 'a3', f: 0 }, { s: 'brex', t: 'a3', f: 0 }, { s: 'bilt', t: 'a3', f: 0 }, { s: 'marriott', t: 'a3', f: 1 }],
+      [{ s: 'amex', t: 'ac', f: 1 }, { s: 'citi', t: 'ac', f: 0 }, { s: 'chase', t: 'ac', f: 1 }, { s: 'c1', t: 'ac', f: 1 }, { s: 'brex', t: 'ac', f: 0 }, { s: 'bilt', t: 'ac', f: 1 }, { s: 'marriott', t: 'ac', f: 1 }],
+      [{ s: 'amex', t: 'ca', f: 0 }, { s: 'citi', t: 'ca', f: 0 }, { s: 'chase', t: 'ca', f: 0 }, { s: 'c1', t: 'ca', f: 0 }, { s: 'brex', t: 'ca', f: 0 }, { s: 'bilt', t: 'ca', f: 0 }, { s: 'marriott', t: 'ca', f: 1 }],
+      [{ s: 'amex', t: 'ai', f: 0 }, { s: 'citi', t: 'ai', f: 0 }, { s: 'chase', t: 'ai', f: 0 }, { s: 'c1', t: 'ai', f: 0 }, { s: 'brex', t: 'ai', f: 0 }, { s: 'bilt', t: 'ai', f: 0 }, { s: 'marriott', t: 'ai', f: 0 }],
+      [{ s: 'amex', t: 'nz', f: 0 }, { s: 'citi', t: 'nz', f: 0 }, { s: 'chase', t: 'nz', f: 0 }, { s: 'c1', t: 'nz', f: 0 }, { s: 'brex', t: 'nz', f: 0 }, { s: 'bilt', t: 'nz', f: 0 }, { s: 'marriott', t: 'nz', f: 1 }],
+      [{ s: 'amex', t: 'nh', f: 1 }, { s: 'citi', t: 'nh', f: 0 }, { s: 'chase', t: 'nh', f: 0 }, { s: 'c1', t: 'nh', f: 0 }, { s: 'brex', t: 'nh', f: 0 }, { s: 'bilt', t: 'nh', f: 0 }, { s: 'marriott', t: 'nh', f: 1 }],
+      [{ s: 'amex', t: 'oz', f: 0 }, { s: 'citi', t: 'oz', f: 0 }, { s: 'chase', t: 'oz', f: 0 }, { s: 'c1', t: 'oz', f: 0 }, { s: 'brex', t: 'oz', f: 0 }, { s: 'bilt', t: 'oz', f: 0 }, { s: 'marriott', t: 'oz', f: 1 }],
+      //[{ s: 'amex', t: 'os', f: 0 }, { s: 'citi', t: 'os', f: 0 }, { s: 'chase', t: 'os', f: 0 }, { s: 'c1', t: 'os', f: 0 }, { s: 'brex', t: 'os', f: 0 }, { s: 'bilt', t: 'os', f: 0 }, { s: 'marriott', t: 'os', f: 0 }],
+      [{ s: 'amex', t: 'av', f: 1 }, { s: 'citi', t: 'av', f: 1 }, { s: 'chase', t: 'av', f: 0 }, { s: 'c1', t: 'av', f: 1 }, { s: 'brex', t: 'av', f: 1 }, { s: 'bilt', t: 'av', f: 0 }, { s: 'marriott', t: 'av', f: 1 }],
+      //[{ s: 'amex', t: 'sn', f: 0 }, { s: 'citi', t: 'sn', f: 0 }, { s: 'chase', t: 'sn', f: 0 }, { s: 'c1', t: 'sn', f: 0 }, { s: 'brex', t: 'sn', f: 0 }, { s: 'bilt', t: 'sn', f: 0 }, { s: 'marriott', t: 'sn', f: 0 }],
+      [{ s: 'amex', t: 'cm', f: 0 }, { s: 'citi', t: 'cm', f: 0 }, { s: 'chase', t: 'cm', f: 0 }, { s: 'c1', t: 'cm', f: 0 }, { s: 'brex', t: 'cm', f: 0 }, { s: 'bilt', t: 'cm', f: 0 }, { s: 'marriott', t: 'cm', f: 1 }],
+      //[{ s: 'amex', t: 'ou', f: 0 }, { s: 'citi', t: 'ou', f: 0 }, { s: 'chase', t: 'ou', f: 0 }, { s: 'c1', t: 'ou', f: 0 }, { s: 'brex', t: 'ou', f: 0 }, { s: 'bilt', t: 'ou', f: 0 }, { s: 'marriott', t: 'ou', f: 0 }],
+      [{ s: 'amex', t: 'ms', f: 0 }, { s: 'citi', t: 'ms', f: 0 }, { s: 'chase', t: 'ms', f: 0 }, { s: 'c1', t: 'ms', f: 0 }, { s: 'brex', t: 'ms', f: 0 }, { s: 'bilt', t: 'ms', f: 0 }, { s: 'marriott', t: 'ms', f: 0 }],
+      [{ s: 'amex', t: 'et', f: 0 }, { s: 'citi', t: 'et', f: 0 }, { s: 'chase', t: 'et', f: 0 }, { s: 'c1', t: 'et', f: 0 }, { s: 'brex', t: 'et', f: 0 }, { s: 'bilt', t: 'et', f: 0 }, { s: 'marriott', t: 'et', f: 0 }],
+      [{ s: 'amex', t: 'br', f: 0 }, { s: 'citi', t: 'br', f: 1 }, { s: 'chase', t: 'br', f: 0 }, { s: 'c1', t: 'br', f: 1 }, { s: 'brex', t: 'br', f: 0 }, { s: 'bilt', t: 'br', f: 0 }, { s: 'marriott', t: 'br', f: 0 }],
+      //[{ s: 'amex', t: 'lo', f: 0 }, { s: 'citi', t: 'lo', f: 0 }, { s: 'chase', t: 'lo', f: 0 }, { s: 'c1', t: 'lo', f: 0 }, { s: 'brex', t: 'lo', f: 0 }, { s: 'bilt', t: 'lo', f: 0 }, { s: 'marriott', t: 'lo', f: 0 }],
+      [{ s: 'amex', t: 'lh', f: 0 }, { s: 'citi', t: 'lh', f: 0 }, { s: 'chase', t: 'lh', f: 0 }, { s: 'c1', t: 'lh', f: 0 }, { s: 'brex', t: 'lh', f: 0 }, { s: 'bilt', t: 'lh', f: 0 }, { s: 'marriott', t: 'lh', f: 0 }],
+      [{ s: 'amex', t: 'sk', f: 0 }, { s: 'citi', t: 'sk', f: 0 }, { s: 'chase', t: 'sk', f: 0 }, { s: 'c1', t: 'sk', f: 0 }, { s: 'brex', t: 'sk', f: 0 }, { s: 'bilt', t: 'sk', f: 0 }, { s: 'marriott', t: 'sk', f: 0 }],
+      [{ s: 'amex', t: 'zh', f: 0 }, { s: 'citi', t: 'zh', f: 0 }, { s: 'chase', t: 'zh', f: 0 }, { s: 'c1', t: 'zh', f: 0 }, { s: 'brex', t: 'zh', f: 0 }, { s: 'bilt', t: 'zh', f: 0 }, { s: 'marriott', t: 'zh', f: 1 }],
+      [{ s: 'amex', t: 'sq', f: 1 }, { s: 'citi', t: 'sq', f: 1 }, { s: 'chase', t: 'sq', f: 1 }, { s: 'c1', t: 'sq', f: 1 }, { s: 'brex', t: 'sq', f: 1 }, { s: 'bilt', t: 'sq', f: 0 }, { s: 'marriott', t: 'sq', f: 1 }],
+      [{ s: 'amex', t: 'sa', f: 0 }, { s: 'citi', t: 'sa', f: 0 }, { s: 'chase', t: 'sa', f: 0 }, { s: 'c1', t: 'sa', f: 0 }, { s: 'brex', t: 'sa', f: 0 }, { s: 'bilt', t: 'sa', f: 0 }, { s: 'marriott', t: 'sa', f: 1 }],
+      //[{ s: 'amex', t: 'lx', f: 0 }, { s: 'citi', t: 'lx', f: 0 }, { s: 'chase', t: 'lx', f: 0 }, { s: 'c1', t: 'lx', f: 0 }, { s: 'brex', t: 'lx', f: 0 }, { s: 'bilt', t: 'lx', f: 0 }, { s: 'marriott', t: 'lx', f: 0 }],
+      [{ s: 'amex', t: 'tp', f: 0 }, { s: 'citi', t: 'tp', f: 0 }, { s: 'chase', t: 'tp', f: 0 }, { s: 'c1', t: 'tp', f: 1 }, { s: 'brex', t: 'tp', f: 0 }, { s: 'bilt', t: 'tp', f: 0 }, { s: 'marriott', t: 'tp', f: 1 }],
+      [{ s: 'amex', t: 'tg', f: 0 }, { s: 'citi', t: 'tg', f: 1 }, { s: 'chase', t: 'tg', f: 0 }, { s: 'c1', t: 'tg', f: 0 }, { s: 'brex', t: 'tg', f: 0 }, { s: 'bilt', t: 'tg', f: 0 }, { s: 'marriott', t: 'tg', f: 1 }],
+      [{ s: 'amex', t: 'tk', f: 0 }, { s: 'citi', t: 'tk', f: 1 }, { s: 'chase', t: 'tk', f: 0 }, { s: 'c1', t: 'tk', f: 1 }, { s: 'brex', t: 'tk', f: 0 }, { s: 'bilt', t: 'tk', f: 1 }, { s: 'marriott', t: 'tk', f: 1 }],
+      [{ s: 'amex', t: 'ua', f: 0 }, { s: 'citi', t: 'ua', f: 0 }, { s: 'chase', t: 'ua', f: 1 }, { s: 'c1', t: 'ua', f: 0 }, { s: 'brex', t: 'ua', f: 0 }, { s: 'bilt', t: 'ua', f: 0 }, { s: 'marriott', t: 'ua', f: 1 }],
     ]
   }];
 
@@ -360,6 +362,8 @@
   var amexColor = '#2E7D32';
   var chaseColor = '#1565C0';
   var citiColor = '#FDD835';
+  var brexColor = '#F46A35';
+  var biltColor = '#AD84EB';
   var noneColor = '#BDBDBD';
 
   var rates = {
@@ -446,6 +450,25 @@
       'ba': "2:1.5",
       'tp': "1:1",
     },
+    "brex": {
+      'am': "1:1",
+      'af': "1:1",
+      'cx': "1:1",
+      'av': "1:1",
+      'ek': "1:1",
+      'b6': "1:1",
+      'qf': "1:1",
+      'sq': "1:1",
+    },
+    "bilt": {
+      'aa': "1:1",
+      'ac': "1:1",
+      'ek': "1:1",
+      'af': "1:1",
+      'tk': "1:1",
+      'vs': "1:1",
+      'ha': "1:1",
+    },
     "marriott": {
       'a3': "3:1.25",
       'su': "3:1.25",
@@ -508,6 +531,8 @@
     if (node.sc === 'amex') { return amexColor; }
     if (node.sc === 'chase') { return chaseColor; }
     if (node.sc === 'citi') { return citiColor; }
+    if (node.sc === 'brex') { return brexColor; }
+    if (node.sc === 'bilt') { return biltColor; }
   })
   .colorLinks(function(link) {
     if ([link.source.sc, link.target.sc].indexOf('c1') >= 0) { return c1Color; }
@@ -515,6 +540,8 @@
     if ([link.source.sc, link.target.sc].indexOf('chase') >= 0) { return chaseColor; }
     if ([link.source.sc, link.target.sc].indexOf('citi') >= 0) { return citiColor; }
     if ([link.source.sc, link.target.sc].indexOf('amex') >= 0) { return amexColor; }
+    if ([link.source.sc, link.target.sc].indexOf('brex') >= 0) { return brexColor; }
+    if ([link.source.sc, link.target.sc].indexOf('bilt') >= 0) { return biltColor; }
     if ([link.source.sc, link.target.sc].indexOf('none') >= 0) { return noneColor; }
   })
   .on("link:mouseover", (link) => {
@@ -522,7 +549,7 @@
     target = link.target,
     source = link.source;
 
-    if (source.sc === "citi" || source.sc === "amex" || source.sc === "chase" || source.sc === "marriott" || source.sc === "c1" || source.sc === "none") {
+    if (source.sc === "citi" || source.sc === "amex" || source.sc === "chase" || source.sc === "marriott" || source.sc === "c1" || source.sc === "brex" || source.sc === "bilt" || source.sc === "none") {
       [target, source] = [source, target];
     }
     rate = rates[target.sc] ? (rates[target.sc][source.sc] || "?:?") : "?:?";


### PR DESCRIPTION
Added [Brex](https://support.brex.com/how-do-i-transfer-my-brex-points-to-airline-miles/) and [Bilt](https://www.biltrewards.com/) transfer partners.

You can preview the changes here:
https://jriest.github.io/Wings-of-the-Points/index.html

Not sure how you feel about adding additional types of transferable points, but I thought it might be helpful to some people. Feel free to decline the Pull Request though if you'd rather not add these.